### PR TITLE
GWTII-164: Porting Feature Info to GWT2 client.

### DIFF
--- a/example-base/src/main/java/org/geomajas/gwt2/example/base/client/resource/showcase.css
+++ b/example-base/src/main/java/org/geomajas/gwt2/example/base/client/resource/showcase.css
@@ -258,6 +258,40 @@ h1,h2,h3,h4,h5,h6 {
 	text-decoration: underline;
 }
 
+@external gwt-ToggleButton, gwt-ToggleButton-up;
+@sprite .gwt-ToggleButton, .gwt-ToggleButton-up {
+    gwt-image: 'header';
+    height: 30px;
+    border-radius: 2px;
+    -moz-border-radius: 2px;
+    color: #FFFFFF;
+    padding: 1px 15px;
+    border: 1px solid #333333;
+}
+
+@external gwt-ToggleButton-down, gwt-ToggleButton-down-hovering;
+.gwt-ToggleButton-down, .gwt-ToggleButton-down-hovering {
+    background: #F0F0F0; /* for non-css3 browsers */
+    background: -webkit-gradient(linear, left top, left bottom, from(#F6F6F6), to(#E8E8E8)); /* for webkit browsers */
+    background: -moz-linear-gradient(top,  #F6F6F6,  #E8E8E8); /* for firefox 3.6+ */
+    height: 30px;
+    border: 1px solid #D0D0D0;
+    border-radius: 2px;
+    padding: 1px 15px;
+    -moz-border-radius: 2px;
+    color: #333333;
+}
+
+@external html-face;
+.html-face {
+    line-height: 30px;
+}
+
+@external gwt-ToggleButton-up-hovering, gwt-ToggleButton-down-hovering;
+.gwt-ToggleButton-up-hovering, .gwt-ToggleButton-down-hovering {
+    text-decoration: underline;
+}
+
 .gwt-Label {
 	line-height: 32px;
 	font-weight: bold;

--- a/example-base/src/main/resources/org/geomajas/gwt2/example/base/ExampleBase.gwt.xml
+++ b/example-base/src/main/resources/org/geomajas/gwt2/example/base/ExampleBase.gwt.xml
@@ -13,13 +13,14 @@
 
 <module rename-to="examplebase">
 
-	<inherits name='com.google.gwt.user.User'/>
-	<inherits name="com.google.gwt.user.theme.standard.Standard" />
+    <inherits name='com.google.gwt.user.User'/>
+    <inherits name="com.google.gwt.user.theme.standard.Standard"/>
 
-	<!-- Geomajas Client -->
-    <inherits name="org.geomajas.gwt2.GeomajasClientImpl" />
+    <!-- Geomajas Client -->
+    <inherits name="org.geomajas.gwt2.GeomajasClientImpl"/>
 
     <entry-point class="org.geomajas.gwt2.example.base.client.ExampleBase"/>
 
-	<source path='client'/>
+    <source path='client'/>
+
 </module>

--- a/example-jar/src/main/java/org/geomajas/gwt2/example/client/ExampleJar.java
+++ b/example-jar/src/main/java/org/geomajas/gwt2/example/client/ExampleJar.java
@@ -231,28 +231,28 @@ public class ExampleJar implements EntryPoint {
 				return "serverexception";
 			}
 		});
-//		SamplePanelRegistry.registerFactory(CATEGORY_GENERAL, new ShowcaseSampleDefinition() {
-//
-//			public SamplePanel create() {
-//				return new MapTraceNavigationPanel();
-//			}
-//
-//			public String getTitle() {
-//				return MESSAGES.generalTraceNavigationTitle();
-//			}
-//
-//			public String getShortDescription() {
-//				return MESSAGES.generalTraceNavigationShort();
-//			}
-//
-//			public String getDescription() {
-//				return MESSAGES.generalTraceNavigationDescription();
-//			}
-//
-//			public String getCategory() {
-//				return CATEGORY_GENERAL;
-//			}
-//		});
+		//		SamplePanelRegistry.registerFactory(CATEGORY_GENERAL, new ShowcaseSampleDefinition() {
+		//
+		//			public SamplePanel create() {
+		//				return new MapTraceNavigationPanel();
+		//			}
+		//
+		//			public String getTitle() {
+		//				return MESSAGES.generalTraceNavigationTitle();
+		//			}
+		//
+		//			public String getShortDescription() {
+		//				return MESSAGES.generalTraceNavigationShort();
+		//			}
+		//
+		//			public String getDescription() {
+		//				return MESSAGES.generalTraceNavigationDescription();
+		//			}
+		//
+		//			public String getCategory() {
+		//				return CATEGORY_GENERAL;
+		//			}
+		//		});
 	}
 
 	private void registerLayerSamples() {

--- a/example-jar/src/main/java/org/geomajas/gwt2/example/client/i18n/SampleMessages.java
+++ b/example-jar/src/main/java/org/geomajas/gwt2/example/client/i18n/SampleMessages.java
@@ -15,7 +15,7 @@ import com.google.gwt.i18n.client.Messages;
 
 /**
  * Specific messages for the many samples.
- * 
+ *
  * @author Pieter De Graef
  */
 public interface SampleMessages extends Messages {

--- a/example-jar/src/main/resources/org/geomajas/gwt2/example/ExampleJar.gwt.xml
+++ b/example-jar/src/main/resources/org/geomajas/gwt2/example/ExampleJar.gwt.xml
@@ -14,6 +14,7 @@
 <module rename-to="examplejar">
 	<inherits name='org.geomajas.gwt2.example.base.ExampleBase' />
     <inherits name='com.allen_sauer.gwt.dnd.gwt-dnd'/>
+    <inherits name="org.geomajas.gwt2.widget.CoreWidget"/>
     <entry-point class="org.geomajas.gwt2.example.client.ExampleJar"/>
 	<source path='client'/>
 

--- a/example/src/main/java/org/geomajas/gwt2/example/Example.gwt.xml
+++ b/example/src/main/java/org/geomajas/gwt2/example/Example.gwt.xml
@@ -22,6 +22,7 @@
     <inherits name='org.geomajas.gwt2.widget.example.ExampleJar' />
 	<inherits name='org.geomajas.plugin.print.example.ExampleJar' />
 	<inherits name='org.geomajas.plugin.graphicsediting.gwt2.example.GraphicsEditingGwt2ExampleJar' />
+    <inherits name="org.geomajas.gwt2.widget.CoreWidget"/>
 
     <entry-point class="org.geomajas.gwt2.example.client.Example" />
 	<!-- set target browser to compile for, use this to limit to the browser used for testing -->

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/CoreWidgetViewFactory.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/CoreWidgetViewFactory.java
@@ -10,24 +10,36 @@
  */
 package org.geomajas.gwt2.widget.client;
 
+import org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoView;
+import org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoViewImpl;
+import org.geomajas.gwt2.widget.client.feature.featureinfo.resource.FeatureInfoResource;
 import org.geomajas.gwt2.widget.client.feature.featureselectbox.FeatureSelectBoxView;
 import org.geomajas.gwt2.widget.client.feature.featureselectbox.FeatureSelectBoxViewImpl;
 import org.geomajas.gwt2.widget.client.feature.featureselectbox.resource.FeatureSelectBoxResource;
 
 /**
  * MVP view factory for this plugin.
- * 
+ *
  * @author Jan De Moerloose
-  * 
  */
 public class CoreWidgetViewFactory {
 
 	/**
 	 * Create a new {@link FeatureSelectBoxView}.
-	 * 
+	 *
 	 * @return the view
 	 */
 	public FeatureSelectBoxView createFeatureSelectBox(FeatureSelectBoxResource resource) {
 		return new FeatureSelectBoxViewImpl(resource);
+	}
+
+	/**
+	 * Create a new {@link org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoView}.
+	 *
+	 * @param resource the resource to use.
+	 * @return a new feature info view.
+	 */
+	public FeatureInfoView createFeatureInfoView(FeatureInfoResource resource) {
+		return new FeatureInfoViewImpl(resource);
 	}
 }

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/FeatureInfoPresenter.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/FeatureInfoPresenter.java
@@ -1,0 +1,39 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo;
+
+import org.geomajas.gwt2.client.map.feature.Feature;
+
+/**
+ * Presenter interface for the {@link org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoWidget}.
+ * The presenter should be able to show a feature, change the visibility of options and zoom
+ * to a specific feature on the map.
+ *
+ * @author Youri Flement
+ */
+public interface FeatureInfoPresenter extends HasFeature {
+
+	/**
+	 * Set the feature to be displayed.
+	 *
+	 * @param feature the feature to display.
+	 */
+	void setFeature(Feature feature);
+
+	/**
+	 * Get the displayed feature.
+	 *
+	 * @return The displayed feature.
+	 */
+	Feature getFeature();
+
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/FeatureInfoPresenterImpl.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/FeatureInfoPresenterImpl.java
@@ -1,0 +1,42 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo;
+
+import org.geomajas.gwt2.client.map.feature.Feature;
+
+/**
+ * Presenter implementation for the {@link org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoWidget}.
+ *
+ * @author Youri Flement
+ */
+public class FeatureInfoPresenterImpl implements FeatureInfoPresenter {
+
+	private FeatureInfoView view;
+
+	private Feature feature;
+
+	public FeatureInfoPresenterImpl(FeatureInfoView view) {
+		this.view = view;
+	}
+
+	@Override
+	public void setFeature(Feature feature) {
+		this.feature = feature;
+		view.setFeature(feature);
+	}
+
+	@Override
+	public Feature getFeature() {
+		return feature;
+	}
+
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/FeatureInfoView.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/FeatureInfoView.java
@@ -1,0 +1,43 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import org.geomajas.annotation.Api;
+import org.geomajas.gwt2.client.map.feature.Feature;
+
+/**
+ * Interface for the {@link org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoWidget}. The view should
+ * be able to display a feature and should provide options to hide or show options to interact
+ * with the feature information.
+ *
+ * @author Youri Flement
+ * @since 2.1.0
+ */
+@Api(allMethods = true)
+public interface FeatureInfoView extends IsWidget, HasFeature {
+
+	/**
+	 * Set the feature to be displayed.
+	 *
+	 * @param feature the feature.
+	 */
+	void setFeature(Feature feature);
+
+	/**
+	 * Set the presenter of the view.
+	 *
+	 * @param presenter the presenter.
+	 */
+	void setPresenter(FeatureInfoPresenter presenter);
+
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/FeatureInfoViewImpl.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/FeatureInfoViewImpl.java
@@ -1,0 +1,120 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.Grid;
+import com.google.gwt.user.client.ui.HTMLTable.CellFormatter;
+import com.google.gwt.user.client.ui.ScrollPanel;
+import com.google.gwt.user.client.ui.Widget;
+import org.geomajas.gwt2.client.map.attribute.AttributeDescriptor;
+import org.geomajas.gwt2.client.map.feature.Feature;
+import org.geomajas.gwt2.widget.client.feature.featureinfo.builder.AttributeWidgetFactory;
+import org.geomajas.gwt2.widget.client.feature.featureinfo.resource.FeatureInfoResource;
+
+/**
+ * View implementation of the {@link org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoWidget}.
+ *
+ * @author Youri Flement
+ */
+public class FeatureInfoViewImpl implements FeatureInfoView {
+
+	private static final AttributeWidgetFactory ATTRIBUTE_FACTORY =
+			GWT.create(AttributeWidgetFactory.class);
+
+	private FeatureInfoPresenter presenter;
+
+	private FeatureInfoResource resource;
+
+	@UiField
+	protected ScrollPanel contentPanel;
+
+	private static final FeatureInfoViewImplUiBinder UI_BINDER = GWT.create(FeatureInfoViewImplUiBinder.class);
+
+	/**
+	 * {@link UiBinder} for this class.
+	 *
+	 * @author Youri Flement
+	 */
+	interface FeatureInfoViewImplUiBinder extends UiBinder<ScrollPanel, FeatureInfoViewImpl> {
+
+	}
+
+	public FeatureInfoViewImpl(FeatureInfoResource resource) {
+		this.resource = resource;
+		this.resource.css().ensureInjected();
+		UI_BINDER.createAndBindUi(this);
+	}
+
+	@Override
+	public void setFeature(Feature feature) {
+		// Clear the current panel:
+		contentPanel.clear();
+
+		// Layout the attributes of the feature in a grid:
+		Grid grid = new Grid(feature.getAttributes().size(), 3);
+		CellFormatter formatter = grid.getCellFormatter();
+		int i = 0;
+		for (AttributeDescriptor descriptor : feature.getLayer().getAttributeDescriptors()) {
+			// Put the attribute label in the first column:
+			grid.setText(i, 0, getAttributeLabel(feature, descriptor));
+			formatter.getElement(i, 0).addClassName(resource.css().attributeLabel());
+
+			// Put a delimiter in the second column:
+			grid.setText(i, 1, getDelimiter());
+
+			// Create a widget for the attribute value and put it in the last column:
+			Widget attributeWidget = ATTRIBUTE_FACTORY.createAttributeWidget(feature, descriptor);
+			attributeWidget.getElement().addClassName(resource.css().attributeValue());
+			grid.setWidget(i, 2, attributeWidget);
+
+			i++;
+		}
+
+		contentPanel.add(grid);
+	}
+
+	/**
+	 * Give developers some way to easily overwrite the default label of an attribute
+	 * and still keep the general layout of the widget.
+	 *
+	 * @param feature    The feature.
+	 * @param descriptor The attribute descriptor.
+	 * @return A label for the attribute.
+	 */
+	protected String getAttributeLabel(Feature feature, AttributeDescriptor descriptor) {
+		return descriptor.getName();
+	}
+
+	/**
+	 * Give developers an easy way to overwrite the default delimiter and still keep the general
+	 * layout of the widget.
+	 *
+	 * @return The delimiter.
+	 */
+	protected String getDelimiter() {
+		return ": ";
+	}
+
+	@Override
+	public void setPresenter(FeatureInfoPresenter presenter) {
+		this.presenter = presenter;
+	}
+
+	@Override
+	public Widget asWidget() {
+		return contentPanel;
+	}
+
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/FeatureInfoViewImpl.ui.xml
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/FeatureInfoViewImpl.ui.xml
@@ -1,0 +1,6 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder" xmlns:g="urn:import:com.google.gwt.user.client.ui">
+
+    <g:ScrollPanel ui:field="contentPanel"/>
+
+</ui:UiBinder>

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/FeatureInfoWidget.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/FeatureInfoWidget.java
@@ -1,0 +1,99 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
+import org.geomajas.annotation.Api;
+import org.geomajas.gwt2.client.map.feature.Feature;
+import org.geomajas.gwt2.widget.client.CoreWidget;
+import org.geomajas.gwt2.widget.client.feature.featureinfo.resource.FeatureInfoResource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Widget to display feature information of a {@link Feature}. By default, the widget displays
+ * the attributes of the feature and provides some options to interact with the feature such
+ * as zooming to the feature. The options can be hidden if needed.
+ *
+ * @author Youri Flement
+ * @since 2.1.0
+ */
+@Api(allMethods = true)
+public class FeatureInfoWidget implements IsWidget, HasFeature {
+
+	private FeatureInfoPresenter presenter;
+
+	private FeatureInfoView view;
+
+	private Collection<HasFeature> actions;
+
+	/**
+	 * Create a new feature info widget with the default resources.
+	 */
+	public FeatureInfoWidget() {
+		this(CoreWidget.getInstance().getClientBundleFactory().createFeatureInfoResource());
+	}
+
+	/**
+	 * Create a new feature info widget with the given map presenter
+	 * and resource.
+	 *
+	 * @param resource The feature info widget resource.
+	 */
+	public FeatureInfoWidget(FeatureInfoResource resource) {
+		view = CoreWidget.getInstance().getViewFactory().createFeatureInfoView(resource);
+		presenter = new FeatureInfoPresenterImpl(view);
+		view.setPresenter(presenter);
+		actions = new ArrayList<HasFeature>();
+	}
+
+	/**
+	 * Set the feature to display.
+	 *
+	 * @param feature The feature.
+	 */
+	@Override
+	public void setFeature(Feature feature) {
+		for (HasFeature action : actions) {
+			action.setFeature(feature);
+		}
+		presenter.setFeature(feature);
+	}
+
+	/**
+	 * Add an object for this feature to the widget. When the displayed feature
+	 * changes, the feature associated with the object is automatically updated.
+	 *
+	 * @param action The action to add.
+	 */
+	public void addHasFeature(HasFeature action) {
+		actions.add(action);
+		action.setFeature(presenter.getFeature());
+	}
+
+	/**
+	 * Remove an object associated with this widget. If the displayed feature changes,
+	 * the feature associated with the object will not be updated anymore.
+	 *
+	 * @param action The action to remove.
+	 */
+	public void removeHasFeature(HasFeature action) {
+		actions.remove(action);
+	}
+
+	@Override
+	public Widget asWidget() {
+		return view.asWidget();
+	}
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/HasFeature.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/HasFeature.java
@@ -1,0 +1,34 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo;
+
+import org.geomajas.annotation.Api;
+import org.geomajas.gwt2.client.map.feature.Feature;
+
+/**
+ * Interface for a class that has a {@link Feature}.
+ * <p/>
+ *
+ * @author Youri Flement
+ * @since 2.1.0
+ */
+@Api(allMethods = true)
+public interface HasFeature {
+
+	/**
+	 * Set the feature associated with the action.
+	 *
+	 * @param feature    The feature.
+	 */
+	void setFeature(Feature feature);
+
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/builder/AttributeWidgetBuilder.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/builder/AttributeWidgetBuilder.java
@@ -1,0 +1,32 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo.builder;
+
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * Interface for an attribute widget builder. A widget builder should be able to build
+ * a widget for a specific attribute of a {@link org.geomajas.gwt2.client.map.feature.Feature}.
+ *
+ * @param <ATTRIBUTE_TYPE> The type of the attribute (StringAttribute, DoubleAttribute, ...)
+ * @author Youri Flement
+ */
+public interface AttributeWidgetBuilder<ATTRIBUTE_TYPE> {
+
+	/**
+	 * Build a custom widget for a specific attribute.
+	 *
+	 * @param attribute the value of the attribute.
+	 * @return the custom widget.
+	 */
+	Widget buildAttributeWidget(ATTRIBUTE_TYPE attribute);
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/builder/AttributeWidgetFactory.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/builder/AttributeWidgetFactory.java
@@ -1,0 +1,106 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo.builder;
+
+import com.google.gwt.user.client.ui.Widget;
+import org.geomajas.annotation.Api;
+import org.geomajas.gwt2.client.map.attribute.Attribute;
+import org.geomajas.gwt2.client.map.attribute.AttributeDescriptor;
+import org.geomajas.gwt2.client.map.feature.Feature;
+import org.geomajas.layer.feature.attribute.BooleanAttribute;
+import org.geomajas.layer.feature.attribute.DoubleAttribute;
+import org.geomajas.layer.feature.attribute.ImageUrlAttribute;
+import org.geomajas.layer.feature.attribute.UrlAttribute;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * A factory to create widgets for feature attributes. By default a feature attribute
+ * is printed as a {@link String} and there are some builders for other primitive datatypes.
+ *
+ * @author Youri Flement
+ * @since 2.1.0
+ */
+@Api(allMethods = true)
+public class AttributeWidgetFactory {
+
+	private static Map<Class<?>, AttributeWidgetBuilder<?>> builders
+			= new HashMap<Class<?>, AttributeWidgetBuilder<?>>();
+
+	static {
+		builders.put(DoubleAttribute.class, new DoubleAttributeWidgetBuilder());
+		builders.put(BooleanAttribute.class, new BooleanAttributeWidgetBuilder());
+		builders.put(ImageUrlAttribute.class, new ImageAttributeWidgetBuilder());
+		builders.put(UrlAttribute.class, new UrlAttributeWidgetBuilder());
+		// add more builders ...
+	}
+
+	/**
+	 * Create a widget for an attribute of a {@link Feature}.
+	 *
+	 * @param feature    the feature of the attribute.
+	 * @param descriptor the descriptor of the attribute of the feature.
+	 * @return the (possible custom) widget for a feature attribute.
+	 */
+	public Widget createAttributeWidget(Feature feature, AttributeDescriptor descriptor) {
+		Attribute<?> attribute = feature.getAttributes().get(descriptor.getName());
+
+		// Get a builder for the attribute
+		// attribute.getValue is e.g. StringAttribute, ImageURLAttribute, ...
+		AttributeWidgetBuilder builder = builders.get(attribute.getValue().getClass());
+		if (builder == null) {
+			builder = new DefaultAttributeWidgetBuilder();
+		}
+
+		// Build the widget and return it:
+		return builder.buildAttributeWidget(attribute.getValue());
+	}
+
+	/**
+	 * Add an attribute builder to the collection. Attributes with the given class will
+	 * have their widgets build by this builder.
+	 * <p/>
+	 * If there is already a builder for the given class it will be overwritten.
+	 *
+	 * @param clazz   the class of the attribute that is handled by the builder.
+	 * @param builder the builder.
+	 */
+	public void addAttributeBuilder(Class<? extends Attribute> clazz, AttributeWidgetBuilder builder) {
+		builders.put(clazz, builder);
+	}
+
+	/**
+	 * Remove an attribute widget builder from the collection.
+	 *
+	 * @param builder the builder to remove.
+	 */
+	public void removeAttributeBuilder(AttributeWidgetBuilder<?> builder) {
+		Iterator<AttributeWidgetBuilder<?>> iterator = builders.values().iterator();
+		while (iterator.hasNext()) {
+			AttributeWidgetBuilder<?> widgetBuilder = iterator.next();
+			if (widgetBuilder.equals(builder)) {
+				iterator.remove();
+			}
+		}
+	}
+
+	/**
+	 * Remove the builder associated with the given attribute class from the collection.
+	 *
+	 * @param clazz the class of the attribute.
+	 */
+	public void removeAttributeBuilder(Class<? extends Attribute> clazz) {
+		builders.remove(clazz);
+	}
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/builder/BooleanAttributeWidgetBuilder.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/builder/BooleanAttributeWidgetBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo.builder;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Widget;
+import org.geomajas.gwt2.widget.client.i18n.WidgetCoreInternationalization;
+import org.geomajas.layer.feature.attribute.BooleanAttribute;
+
+/**
+ * Widget builder for {@link Boolean} attributes. Translates boolean values to internationalized
+ * <code>yes</code> and <code>no</code> Strings.
+ *
+ * @author Youri Flement
+ */
+public class BooleanAttributeWidgetBuilder implements AttributeWidgetBuilder<BooleanAttribute> {
+
+	private static final WidgetCoreInternationalization MSG = GWT.create(WidgetCoreInternationalization.class);
+
+	@Override
+	public Widget buildAttributeWidget(BooleanAttribute attribute) {
+		Label label = new Label();
+
+		// Simply put "yes" or "no" instead of 1 and 0.
+		if (attribute.getValue()) {
+			label.getElement().setInnerText(MSG.yes());
+		} else {
+			label.getElement().setInnerText(MSG.no());
+		}
+		return label;
+	}
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/builder/DefaultAttributeWidgetBuilder.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/builder/DefaultAttributeWidgetBuilder.java
@@ -1,0 +1,28 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo.builder;
+
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * Default Widget builder.
+ *
+ * @author Youri Flement
+ */
+public class DefaultAttributeWidgetBuilder implements AttributeWidgetBuilder<Object> {
+
+	@Override
+	public Widget buildAttributeWidget(Object attribute) {
+		return new Label(attribute.toString());
+	}
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/builder/DoubleAttributeWidgetBuilder.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/builder/DoubleAttributeWidgetBuilder.java
@@ -1,0 +1,29 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo.builder;
+
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Widget;
+import org.geomajas.layer.feature.attribute.DoubleAttribute;
+
+/**
+ * Widget builder for {@link Double} attributes.
+ *
+ * @author Youri Flement
+ */
+public class DoubleAttributeWidgetBuilder implements AttributeWidgetBuilder<DoubleAttribute> {
+
+	@Override
+	public Widget buildAttributeWidget(DoubleAttribute attribute) {
+		return new Label(attribute.getValue() + "");
+	}
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/builder/ImageAttributeWidgetBuilder.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/builder/ImageAttributeWidgetBuilder.java
@@ -1,0 +1,29 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo.builder;
+
+import com.google.gwt.user.client.ui.Image;
+import com.google.gwt.user.client.ui.Widget;
+import org.geomajas.layer.feature.attribute.StringAttribute;
+
+/**
+ * Widget builder for attributes whose value are a path to an image.
+ *
+ * @author Youri Flement
+ */
+public class ImageAttributeWidgetBuilder implements AttributeWidgetBuilder<StringAttribute> {
+
+	@Override
+	public Widget buildAttributeWidget(StringAttribute imagePath) {
+		return new Image(imagePath.getValue());
+	}
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/builder/UrlAttributeWidgetBuilder.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/builder/UrlAttributeWidgetBuilder.java
@@ -1,0 +1,29 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo.builder;
+
+import com.google.gwt.user.client.ui.Anchor;
+import com.google.gwt.user.client.ui.Widget;
+import org.geomajas.layer.feature.attribute.StringAttribute;
+
+/**
+ * Widget builder for an attribute whose values is an <code>URL</code>.
+ *
+ * @author Youri Flement
+ */
+public class UrlAttributeWidgetBuilder implements AttributeWidgetBuilder<StringAttribute> {
+
+	@Override
+	public Widget buildAttributeWidget(StringAttribute url) {
+		return new Anchor(url.getValue());
+	}
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/resource/FeatureInfoCssResource.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/resource/FeatureInfoCssResource.java
@@ -1,0 +1,28 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo.resource;
+
+import com.google.gwt.resources.client.CssResource;
+
+/**
+ * CSS resource for the {@link org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoWidget}.
+ *
+ * @author Youri Flement
+ */
+public interface FeatureInfoCssResource extends CssResource {
+
+	@ClassName("gm-attributeLabel")
+	String attributeLabel();
+
+	@ClassName("gm-attributeValue")
+	String attributeValue();
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/resource/FeatureInfoResource.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/resource/FeatureInfoResource.java
@@ -1,0 +1,30 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo.resource;
+
+import com.google.gwt.resources.client.ClientBundle;
+import org.geomajas.gwt2.widget.client.CoreWidget;
+
+/**
+ * Resource bundle for the {@link org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoWidget}.
+ *
+ * @author Youri Flement
+ */
+public interface FeatureInfoResource extends ClientBundle {
+
+	FeatureInfoResource INSTANCE = CoreWidget.getInstance().getClientBundleFactory()
+			.createFeatureInfoResource();
+
+	@Source("featureInfo.css")
+	FeatureInfoCssResource css();
+
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/resource/FeatureInfoResourceNoStyle.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/resource/FeatureInfoResourceNoStyle.java
@@ -1,0 +1,26 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.client.feature.featureinfo.resource;
+
+import org.geomajas.gwt2.widget.client.feature.featureselectbox.resource.FeatureSelectBoxCssResource;
+import org.geomajas.gwt2.widget.client.feature.featureselectbox.resource.FeatureSelectBoxResource;
+
+/**
+ * CSS resource to remove style of the {@link org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoWidget}.
+ *
+ * @author Youri Flement
+ */
+public interface FeatureInfoResourceNoStyle extends FeatureSelectBoxResource {
+
+	@Source("featureInfo-nostyle.css")
+	FeatureSelectBoxCssResource css();
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/resource/featureInfo-nostyle.css
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/resource/featureInfo-nostyle.css
@@ -1,0 +1,9 @@
+@external gm-attributeLabel;
+.gm-attributeLabel {
+
+}
+
+@external gm-attributeValue;
+.gm-attributeValue {
+
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/resource/featureInfo.css
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/feature/featureinfo/resource/featureInfo.css
@@ -1,0 +1,11 @@
+@external gm-attributeLabel;
+.gm-attributeLabel {
+    text-align: right;
+}
+
+@external gm-attributeValue;
+.gm-attributeValue {
+    text-decoration: none;
+    font-weight: normal;
+    line-height: normal;
+}

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/i18n/WidgetCoreInternationalization.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/i18n/WidgetCoreInternationalization.java
@@ -15,8 +15,7 @@ import com.google.gwt.i18n.client.Messages;
 
 /**
  * Localization constants for the GWT client widgets.
- *
- * FIXME: per widget
+ * <p/>
  *
  * @author Dosi Bingov
  */
@@ -28,8 +27,19 @@ public interface WidgetCoreInternationalization extends Messages {
 
 	/*	Message box widget messages */
 	String messageBoxBtnYes();
+
 	String messageBoxBtnNo();
+
 	String messageBoxBtnCancel();
+
 	String messageBoxBtnClose();
 
+	/* Feature info widget messages */
+	String featureDetailTitle();
+
+	String zoomToObjectButton();
+
+	String yes();
+
+	String no();
 }

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/resource/CoreWidgetClientBundleFactory.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/resource/CoreWidgetClientBundleFactory.java
@@ -11,9 +11,9 @@
 
 package org.geomajas.gwt2.widget.client.resource;
 
-import org.geomajas.gwt2.widget.client.feature.featureselectbox.resource.FeatureSelectBoxResource;
-
 import com.google.gwt.core.client.GWT;
+import org.geomajas.gwt2.widget.client.feature.featureinfo.resource.FeatureInfoResource;
+import org.geomajas.gwt2.widget.client.feature.featureselectbox.resource.FeatureSelectBoxResource;
 
 /**
  * Default factory for client bundles defined within this artifact. By using such a factory, it is possible to easily
@@ -26,11 +26,19 @@ public class CoreWidgetClientBundleFactory {
 	/**
 	 * Create a new resource bundle for the
 	 * {@link org.geomajas.gwt2.widget.client.FeatureSelectBox.FeatureSelectListener} widget.
-	 * 
+	 *
 	 * @return A new resource bundle.
 	 */
 	public FeatureSelectBoxResource createFeatureSelectBoxResource() {
 		return GWT.create(FeatureSelectBoxResource.class);
 	}
 
+	/**
+	 * Create a new resource bundle for the {@link org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoWidget}.
+	 *
+	 * @return A new resource bundle.
+	 */
+	public FeatureInfoResource createFeatureInfoResource() {
+		return GWT.create(FeatureInfoResource.class);
+	}
 }

--- a/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/resource/CoreWidgetClientBundleFactoryNoStyle.java
+++ b/plugin/corewidget/corewidget/src/main/java/org/geomajas/gwt2/widget/client/resource/CoreWidgetClientBundleFactoryNoStyle.java
@@ -11,14 +11,15 @@
 
 package org.geomajas.gwt2.widget.client.resource;
 
+import com.google.gwt.core.client.GWT;
+import org.geomajas.gwt2.widget.client.feature.featureinfo.resource.FeatureInfoResource;
+import org.geomajas.gwt2.widget.client.feature.featureinfo.resource.FeatureInfoResourceNoStyle;
 import org.geomajas.gwt2.widget.client.feature.featureselectbox.resource.FeatureSelectBoxResource;
 import org.geomajas.gwt2.widget.client.feature.featureselectbox.resource.FeatureSelectBoxResourceNoStyle;
 
-import com.google.gwt.core.client.GWT;
-
 /**
  * No style factory for client bundles defined within this artifact. This factory wipes out all css.
- * 
+ *
  * @author Jan De Moerloose
  */
 public class CoreWidgetClientBundleFactoryNoStyle extends CoreWidgetClientBundleFactory {
@@ -26,11 +27,20 @@ public class CoreWidgetClientBundleFactoryNoStyle extends CoreWidgetClientBundle
 	/**
 	 * Create an empty resource bundle for the
 	 * {@link org.geomajas.gwt2.widget.client.FeatureSelectBox.FeatureSelectListener} widget.
-	 * 
+	 *
 	 * @return A new resource bundle.
 	 */
 	public FeatureSelectBoxResource createFeatureSelectBoxResource() {
 		return GWT.create(FeatureSelectBoxResourceNoStyle.class);
+	}
+
+	/**
+	 * Create an empty resource bundle for the {@link org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoWidget}.
+	 *
+	 * @return A new resource bundle.
+	 */
+	public FeatureInfoResource createFeatureInfoResource() {
+		return GWT.create(FeatureInfoResourceNoStyle.class);
 	}
 
 }

--- a/plugin/corewidget/corewidget/src/main/resources/org/geomajas/gwt2/widget/CoreWidget.gwt.xml
+++ b/plugin/corewidget/corewidget/src/main/resources/org/geomajas/gwt2/widget/CoreWidget.gwt.xml
@@ -11,6 +11,7 @@
 
 <module>
     <inherits name="org.geomajas.gwt2.GeomajasClientImpl"/>
+    <inherits name="org.geomajas.gwt2.GeomajasClientServerExtension"/>
 
     <source path="client">
         <exclude name="*Test*.java"/>

--- a/plugin/corewidget/corewidget/src/main/resources/org/geomajas/gwt2/widget/client/i18n/WidgetCoreInternationalization.properties
+++ b/plugin/corewidget/corewidget/src/main/resources/org/geomajas/gwt2/widget/client/i18n/WidgetCoreInternationalization.properties
@@ -18,3 +18,9 @@ messageBoxBtnYes=Yes
 messageBoxBtnNo=No
 messageBoxBtnCancel=Cancel
 messageBoxBtnClose=Close
+
+# Feature detail widget
+featureDetailTitle=Feature detail
+zoomToObjectButton=Zoom to object
+yes=Yes
+no=No

--- a/plugin/corewidget/corewidget/src/main/resources/org/geomajas/gwt2/widget/client/i18n/WidgetCoreInternationalization_nl.properties
+++ b/plugin/corewidget/corewidget/src/main/resources/org/geomajas/gwt2/widget/client/i18n/WidgetCoreInternationalization_nl.properties
@@ -19,3 +19,9 @@ messageBoxBtnYes=Ja
 messageBoxBtnNo=Nee
 messageBoxBtnCancel=Annuleer
 messageBoxBtnClose=Sluiten
+
+# Feature detail widget
+featureDetailTitle=Feature detail
+zoomToObjectButton=Ga naar feature
+yes=Ja
+no=Nee

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/ExampleJar.java
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/ExampleJar.java
@@ -11,6 +11,8 @@
 
 package org.geomajas.gwt2.widget.example.client;
 
+import com.google.gwt.core.client.EntryPoint;
+import com.google.gwt.core.client.GWT;
 import org.geomajas.gwt2.example.base.client.sample.SamplePanel;
 import org.geomajas.gwt2.example.base.client.sample.SamplePanelRegistry;
 import org.geomajas.gwt2.example.base.client.sample.ShowcaseSampleDefinition;
@@ -19,17 +21,15 @@ import org.geomajas.gwt2.widget.example.client.resource.ExampleWidgetResource;
 import org.geomajas.gwt2.widget.example.client.sample.dialog.CloseableDialogExample;
 import org.geomajas.gwt2.widget.example.client.sample.dialog.MessageBoxExample;
 import org.geomajas.gwt2.widget.example.client.sample.feature.FeatureClickedExample;
+import org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo.FeatureInfoPanel;
 import org.geomajas.gwt2.widget.example.client.sample.map.LegendAddRemoveSample;
 import org.geomajas.gwt2.widget.example.client.sample.map.LegendOrderSample;
 import org.geomajas.gwt2.widget.example.client.sample.map.MapLegendDropDownSample;
 import org.geomajas.gwt2.widget.example.client.sample.mouseover.FeatureMouseOverExample;
 
-import com.google.gwt.core.client.EntryPoint;
-import com.google.gwt.core.client.GWT;
-
 /**
  * Entry point and main class for the widget core example application.
- * 
+ *
  * @author Pieter De Graef
  */
 public class ExampleJar implements EntryPoint {
@@ -247,10 +247,43 @@ public class ExampleJar implements EntryPoint {
 				return CATEGORY_WIDGET;
 			}
 
-					@Override
-					public String getKey() {
-						return "FeatureMouseOver";
-					}
-				});
+			@Override
+			public String getKey() {
+				return "FeatureMouseOver";
+			}
+		});
+
+		SamplePanelRegistry.registerFactory(CATEGORY_WIDGET, new ShowcaseSampleDefinition() {
+			@Override
+			public SamplePanel create() {
+				return new FeatureInfoPanel();
+			}
+
+			@Override
+			public String getTitle() {
+				return MESSAGES.featureInfoTitle();
+			}
+
+			@Override
+			public String getShortDescription() {
+				return MESSAGES.featureInfoShort();
+			}
+
+			@Override
+			public String getDescription() {
+				return MESSAGES.featureInfoDescription();
+			}
+
+			@Override
+			public String getCategory() {
+				return CATEGORY_WIDGET;
+			}
+
+			@Override
+			public String getKey() {
+				return "featureinfo";
+			}
+		});
+
 	}
 }

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/i18n/SampleMessages.java
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/i18n/SampleMessages.java
@@ -26,31 +26,51 @@ public interface SampleMessages extends Messages {
 	// ------------------------------------------------------------------------
 
 	String closeableDialogTitle();
+
 	String closeableDialogDescrShort();
+
 	String closeableDialogDescription();
+
 	String closeableDialogButShow();
 
 	String messageBoxTitle();
+
 	String messageBoxDescrShort();
+
 	String messageBoxDescription();
+
 	String messageBoxInfoMessageBtn();
+
 	String messageBoxWarnMessageBtn();
+
 	String messageBoxErrorMessageBtn();
+
 	String messageBoxHelpMessageBtn();
+
 	String messageBoxYesNoBtn();
+
 	String messageBoxYesNoCancelBtn();
+
 	String messageBoxMessage();
+
 	String messageBoxResponseYes();
+
 	String messageBoxResponseNo();
+
 	String messageBoxResponseCancel();
+
 	SafeHtml messageBoxMessageLong();
 
 	String featureSelectedTitle();
+
 	String featureSelectedDescrShort();
+
 	String featureSelectedDescription();
 
 	String featureMouseOverTitle();
+
 	String featureMouseOverDescrShort();
+
 	String featureMouseOverDescription();
 
 	// ------------------------------------------------------------------------
@@ -102,4 +122,10 @@ public interface SampleMessages extends Messages {
 	String itemSelectThirdItem();
 
 	String itemSelectYouSelected(String item);
+
+	String featureInfoTitle();
+
+	String featureInfoShort();
+
+	String featureInfoDescription();
 }

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/FeatureInfoPanel.java
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/FeatureInfoPanel.java
@@ -1,0 +1,130 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.DecoratorPanel;
+import com.google.gwt.user.client.ui.DockLayoutPanel;
+import com.google.gwt.user.client.ui.HTMLPanel;
+import com.google.gwt.user.client.ui.ResizeLayoutPanel;
+import com.google.gwt.user.client.ui.Widget;
+import org.geomajas.gwt2.client.GeomajasImpl;
+import org.geomajas.gwt2.client.GeomajasServerExtension;
+import org.geomajas.gwt2.client.event.MapInitializationEvent;
+import org.geomajas.gwt2.client.event.MapInitializationHandler;
+import org.geomajas.gwt2.client.map.MapPresenter;
+import org.geomajas.gwt2.client.map.feature.Feature;
+import org.geomajas.gwt2.example.base.client.ExampleBase;
+import org.geomajas.gwt2.example.base.client.sample.SamplePanel;
+import org.geomajas.gwt2.widget.client.feature.event.FeatureClickedEvent;
+import org.geomajas.gwt2.widget.client.feature.event.FeatureClickedHandler;
+import org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo.control.FeatureInfoControlWidget;
+
+/**
+ * Panel for the feature info sample.
+ *
+ * @author Youri Flement
+ */
+public class FeatureInfoPanel implements SamplePanel, FeatureClickedHandler {
+
+	private MapPresenter mapPresenter;
+
+	protected DockLayoutPanel rootPanel;
+
+	@UiField
+	protected HTMLPanel leftPanel;
+
+	@UiField
+	protected ResizeLayoutPanel mapPanel;
+
+	private static final FeatureInfoPanelUiBinder UI_BINDER = GWT.create(FeatureInfoPanelUiBinder.class);
+
+	/**
+	 * The Feature Info Widget (with actions) we will display in the left panel.
+	 */
+	private FeatureInfoWithActions featureInfoWidget;
+
+	/**
+	 * {@link UiBinder} for this class.
+	 *
+	 * @author Youri Flement
+	 */
+	interface FeatureInfoPanelUiBinder extends UiBinder<DockLayoutPanel, FeatureInfoPanel> {
+
+	}
+
+	public FeatureInfoPanel() {
+		rootPanel = UI_BINDER.createAndBindUi(this);
+
+		// Create the MapPresenter and add an InitializationHandler:
+		mapPresenter = GeomajasImpl.getInstance().createMapPresenter();
+		mapPresenter.setSize(480, 480);
+		mapPresenter.getEventBus().addMapInitializationHandler(new MyMapInitializationHandler());
+
+		// Add the map to the GUI, using a decorator for nice borders:
+		DecoratorPanel mapDecorator = new DecoratorPanel();
+		mapDecorator.add(mapPresenter.asWidget());
+		mapPanel.add(mapDecorator);
+
+		// Add a feature info control to the map (displays feature info in a dialogbox):
+		leftPanel.add(new FeatureInfoControlWidget(mapPresenter).asWidget());
+
+		// Also show feature information in the side panel:
+		mapPresenter.getEventBus().addHandler(FeatureClickedHandler.TYPE, this);
+
+		// Initialize the map
+		GeomajasServerExtension.getInstance().initializeMap(mapPresenter, "gwt-app", "mapCountries");
+	}
+
+	/**
+	 * Action called when a feature is clicked. Displays the information of the clicked
+	 * feature in the left panel of the sample, overwriting any feature info that may
+	 * be already there.
+	 *
+	 * @param event {@link FeatureClickedEvent}
+	 */
+	@Override
+	public void onFeatureClicked(FeatureClickedEvent event) {
+		// Create feature info widget if this is the first time displaying a feature:
+		if (featureInfoWidget == null) {
+			// Create info widget with some actions:
+			FeatureInfoWidgetFactory factory = new FeatureInfoWidgetFactory();
+			featureInfoWidget = factory.getFeatureInfoWidgetWithActions(mapPresenter);
+			leftPanel.add(featureInfoWidget);
+		}
+
+		// (Over)write the feature of the widget:
+		Feature feature = event.getFeature();
+		if (feature != null) {
+			featureInfoWidget.setFeature(event.getFeature());
+		}
+	}
+
+	@Override
+	public Widget asWidget() {
+		return rootPanel;
+	}
+
+	/**
+	 * {@link MapInitializationHandler} for this sample.
+	 *
+	 * @author Youri Flement
+	 */
+	private class MyMapInitializationHandler implements MapInitializationHandler {
+
+		public void onMapInitialized(MapInitializationEvent event) {
+			mapPresenter.getViewPort().applyBounds(ExampleBase.BBOX_AFRICA);
+		}
+	}
+}

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/FeatureInfoPanel.ui.xml
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/FeatureInfoPanel.ui.xml
@@ -1,0 +1,20 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder" xmlns:g="urn:import:com.google.gwt.user.client.ui">
+
+    <ui:with field='resource' type='org.geomajas.gwt2.example.base.client.resource.ShowcaseResource'/>
+
+
+    <g:DockLayoutPanel unit="PX" width="100%" height="100%">
+        <g:west size="350">
+            <g:HTMLPanel ui:field="leftPanel" addStyleNames="{resource.css.sampleLeftLayout}">
+                Toggle the button to enable/disable feature information popups on clicking a feature.
+            </g:HTMLPanel>
+        </g:west>
+        <g:center>
+            <g:SimplePanel addStyleNames="{resource.css.sampleContentLayout}">
+                <g:ResizeLayoutPanel ui:field="mapPanel" width="100%" height="100%"/>
+            </g:SimplePanel>
+        </g:center>
+    </g:DockLayoutPanel>
+
+</ui:UiBinder>

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/FeatureInfoWidgetFactory.java
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/FeatureInfoWidgetFactory.java
@@ -1,0 +1,48 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo;
+
+import org.geomajas.gwt2.client.map.MapPresenter;
+import org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoWidget;
+
+/**
+ * Factory for creating feature info widgets.
+ *
+ * @author Youri Flement
+ */
+public class FeatureInfoWidgetFactory {
+
+	/**
+	 * Create a default {@link FeatureInfoWidget}. No actions or resources are
+	 * given to the widget.
+	 *
+	 * @return The default {@link FeatureInfoWidget}.
+	 */
+	public FeatureInfoWidget getDefaultFeatureInfoWidget() {
+		return new FeatureInfoWidget();
+	}
+
+	/**
+	 * Create a default {@link FeatureInfoWidget} with a {@link ZoomToObjectAction}
+	 * to allow zooming to selected features.
+	 *
+	 * @param mapPresenter The map presenter used by the action(s).
+	 * @return A feature info widget with actions.
+	 */
+	public FeatureInfoWithActions getFeatureInfoWidgetWithActions(MapPresenter mapPresenter) {
+		FeatureInfoWithActions widgetWithActions = new FeatureInfoWithActions();
+		widgetWithActions.addHasFeature(new ZoomToObjectAction(mapPresenter));
+
+		return widgetWithActions;
+	}
+
+}

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/FeatureInfoWithActions.java
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/FeatureInfoWithActions.java
@@ -1,0 +1,67 @@
+/*
+ *
+ *  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *  *
+ *  * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *  *
+ *  * The program is available in open source according to the GNU Affero
+ *  * General Public License. All contributions in this program are covered
+ *  * by the Geomajas Contributors License Agreement. For full licensing
+ *  * details, see LICENSE.txt in the project root.
+ *
+ */
+
+package org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
+import org.geomajas.gwt2.client.map.feature.Feature;
+import org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoWidget;
+import org.geomajas.gwt2.widget.client.feature.featureinfo.HasFeature;
+
+/**
+ * Wrapper for a {@link FeatureInfoWidget} with actions.
+ *
+ * @author Youri Flement
+ */
+public class FeatureInfoWithActions implements HasFeature, IsWidget {
+
+	private VerticalPanel panel;
+
+	private FeatureInfoWidget widget;
+
+	/**
+	 * Create a new feature info widget with no widgets.
+	 */
+	public FeatureInfoWithActions() {
+		this.widget = new FeatureInfoWidget();
+		panel = new VerticalPanel();
+		panel.add(widget);
+	}
+
+	/**
+	 * Add a {@link HasFeature} to the feature info widget. This will typically
+	 * be an action to interact with the feature (info). If the HasFeature is a widget
+	 * it will be added to the panel.
+	 *
+	 * @param hasFeature The HasFeature to add.
+	 */
+	public void addHasFeature(HasFeature hasFeature) {
+		widget.addHasFeature(hasFeature);
+
+		if (hasFeature instanceof Widget) {
+			panel.insert((Widget) hasFeature, panel.getWidgetCount() - 1);
+		}
+	}
+
+	@Override
+	public Widget asWidget() {
+		return panel;
+	}
+
+	@Override
+	public void setFeature(Feature feature) {
+		widget.setFeature(feature);
+	}
+}

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/MyAttributeWidgetFactory.java
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/MyAttributeWidgetFactory.java
@@ -1,0 +1,60 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo;
+
+import com.google.gwt.i18n.client.NumberFormat;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
+import org.geomajas.gwt2.client.map.attribute.Attribute;
+import org.geomajas.gwt2.client.map.attribute.AttributeDescriptor;
+import org.geomajas.gwt2.client.map.feature.Feature;
+import org.geomajas.gwt2.widget.client.feature.featureinfo.builder.AttributeWidgetFactory;
+import org.geomajas.layer.feature.attribute.DoubleAttribute;
+
+/**
+ * Factory to create attribute widgets. Overwrites the default attribute factory
+ * {@link org.geomajas.gwt2.widget.client.feature.featureinfo.builder.AttributeWidgetFactory}. Requests for building attributes with a
+ * value of {@link Double} are intercepted and a custom widget for these attributes is build.
+ * Other attributes are delegated to the default factory.
+ *
+ * @author Youri Flement
+ */
+public class MyAttributeWidgetFactory extends AttributeWidgetFactory {
+
+	@Override
+	public Widget createAttributeWidget(Feature feature, AttributeDescriptor descriptor) {
+		Attribute<?> attributeValue = feature.getAttributes().get(descriptor.getName());
+
+		Widget widget;
+		if (attributeValue.getValue() instanceof DoubleAttribute) {
+			widget = createDoubleWidget((DoubleAttribute) attributeValue.getValue());
+		} else {
+			widget = super.createAttributeWidget(feature, descriptor);
+		}
+
+		return widget;
+	}
+
+	/**
+	 * Create a custom widget for attributes of type {@link Double}. Simply applies a number
+	 * formatter on the attribute value and puts it in a panel.
+	 *
+	 * @param attributeValue the value of the attribute.
+	 * @return the custom widget.
+	 */
+	private Widget createDoubleWidget(DoubleAttribute attributeValue) {
+		VerticalPanel panel = new VerticalPanel();
+		String formattedNumber = NumberFormat.getDecimalFormat().format(attributeValue.getValue());
+		panel.getElement().setInnerText(formattedNumber);
+		return panel;
+	}
+}

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/ZoomToObjectAction.java
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/ZoomToObjectAction.java
@@ -1,0 +1,54 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo;
+
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.user.client.ui.Button;
+import org.geomajas.geometry.Bbox;
+import org.geomajas.geometry.service.GeometryService;
+import org.geomajas.gwt2.client.map.MapPresenter;
+import org.geomajas.gwt2.client.map.ZoomOption;
+import org.geomajas.gwt2.client.map.feature.Feature;
+import org.geomajas.gwt2.widget.client.feature.featureinfo.HasFeature;
+
+/**
+ * Implementation of a {@link HasFeature} to zoom to a feature on the map.
+ *
+ * @author Youri Flement
+ */
+public class ZoomToObjectAction extends Button implements HasFeature, ClickHandler {
+
+	protected Feature feature;
+
+	protected MapPresenter mapPresenter;
+
+	public ZoomToObjectAction(MapPresenter mapPresenter) {
+		setText("Zoom to object");
+		addClickHandler(this);
+		this.mapPresenter = mapPresenter;
+	}
+
+	@Override
+	public void setFeature(Feature feature) {
+		this.feature = feature;
+	}
+
+	@Override
+	public void onClick(ClickEvent event) {
+		if (feature != null) {
+			// Get bounds and zoom:
+			Bbox bounds = GeometryService.getBounds(feature.getGeometry());
+			mapPresenter.getViewPort().applyBounds(bounds, ZoomOption.LEVEL_FIT);
+		}
+	}
+}

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControl.java
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControl.java
@@ -1,0 +1,44 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo.control;
+
+import com.google.gwt.core.client.GWT;
+
+/**
+ * Control widget for displaying {@link org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoWidget}s.
+ *
+ * @author Youri Flement
+ */
+public final class FeatureInfoControl {
+
+	private static FeatureInfoControl instance;
+
+	private FeatureInfoControlViewFactory viewFactory;
+
+	private FeatureInfoControl() {
+	}
+
+	public FeatureInfoControlViewFactory getViewFactory() {
+		if (viewFactory == null) {
+			viewFactory = GWT.create(FeatureInfoControlViewFactory.class);
+		}
+		return viewFactory;
+	}
+
+	public static FeatureInfoControl getInstance() {
+		if (instance == null) {
+			instance = new FeatureInfoControl();
+		}
+		return instance;
+	}
+
+}

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControlPresenter.java
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControlPresenter.java
@@ -1,0 +1,36 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo.control;
+
+import org.geomajas.gwt2.client.map.MapPresenter;
+
+/**
+ * Presenter interface for the {@link FeatureInfoControl}.
+ * The presenter allows to disable/enable the displaying of feature info, e.g. the underlying control can be a
+ * toggle button.
+ *
+ * @author Youri Flement
+ */
+public interface FeatureInfoControlPresenter {
+
+	void setMapPresenter(MapPresenter mapPresenter);
+
+	/**
+	 * Enable showing feature info when a feature is clicked.
+	 */
+	void enableFeatureInfo();
+
+	/**
+	 * Disable showing feature info when a feature is clicked.
+	 */
+	void disableFeatureInfo();
+}

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControlPresenterImpl.java
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControlPresenterImpl.java
@@ -1,0 +1,80 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo.control;
+
+import com.google.gwt.dom.client.Style.Unit;
+import org.geomajas.gwt2.client.map.MapPresenter;
+import org.geomajas.gwt2.client.map.feature.Feature;
+import org.geomajas.gwt2.example.base.client.widget.ShowcaseDialogBox;
+import org.geomajas.gwt2.widget.client.feature.controller.FeatureClickedListener;
+import org.geomajas.gwt2.widget.client.feature.event.FeatureClickedEvent;
+import org.geomajas.gwt2.widget.client.feature.event.FeatureClickedHandler;
+import org.geomajas.gwt2.widget.client.feature.featureinfo.FeatureInfoWidget;
+import org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo.FeatureInfoWidgetFactory;
+
+/**
+ * Presenter implementation for the {@link FeatureInfoControl}.
+ * The presenter listens to {@link FeatureClickedEvent}s and
+ * displays the features in a dialog box.
+ *
+ * @author Youri Flement
+ */
+public class FeatureInfoControlPresenterImpl implements FeatureInfoControlPresenter, FeatureClickedHandler {
+
+	private MapPresenter mapPresenter;
+
+	private boolean enabled;
+
+	public FeatureInfoControlPresenterImpl() {
+		enabled = false;
+	}
+
+	@Override
+	public void setMapPresenter(MapPresenter mapPresenter) {
+		this.mapPresenter = mapPresenter;
+		this.mapPresenter.addMapListener(new FeatureClickedListener());
+		this.mapPresenter.getEventBus().addHandler(FeatureClickedHandler.TYPE, this);
+	}
+
+	@Override
+	public void enableFeatureInfo() {
+		enabled = true;
+	}
+
+	@Override
+	public void disableFeatureInfo() {
+		enabled = false;
+	}
+
+	@Override
+	public void onFeatureClicked(FeatureClickedEvent event) {
+		if (enabled) {
+			Feature feature = event.getFeature();
+			if (feature != null) {
+				// Create a default feature info widget:
+				FeatureInfoWidgetFactory factory = new FeatureInfoWidgetFactory();
+				FeatureInfoWidget featureInfo = factory.getDefaultFeatureInfoWidget();
+				featureInfo.asWidget().getElement().getStyle().setWidth(250, Unit.PX);
+				featureInfo.setFeature(feature);
+
+				// Put it all in a dialog box:
+				ShowcaseDialogBox dialogBox = new ShowcaseDialogBox();
+				String title = "Feature detail: " + feature.getLabel();
+				dialogBox.setWidget(featureInfo);
+				dialogBox.setText(title);
+				dialogBox.setTitle(title);
+				dialogBox.setModal(false);
+				dialogBox.show();
+			}
+		}
+	}
+}

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControlView.java
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControlView.java
@@ -1,0 +1,31 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo.control;
+
+import com.google.gwt.user.client.ui.IsWidget;
+
+/**
+ * View interface of {@link org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo.control.FeatureInfoControl}.
+ * The view has only methods for setting the presenter.
+ *
+ * @author Youri Flement
+ */
+public interface FeatureInfoControlView extends IsWidget {
+
+	/**
+	 * Set the presenter that will handle the events when the control is clicked.
+	 *
+	 * @param presenter the presenter.
+	 */
+	void setPresenter(FeatureInfoControlPresenter presenter);
+
+}

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControlViewFactory.java
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControlViewFactory.java
@@ -1,0 +1,25 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo.control;
+
+/**
+ * View factory for the {@link org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo.control.FeatureInfoControl}.
+ *
+ * @author Youri Flement
+ */
+public class FeatureInfoControlViewFactory {
+
+	public FeatureInfoControlView createFeatureInfoControlView() {
+		return new FeatureInfoControlViewImpl();
+	}
+
+}

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControlViewImpl.java
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControlViewImpl.java
@@ -1,0 +1,78 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo.control;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style.TextAlign;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
+import com.google.gwt.user.client.ui.HTMLPanel;
+import com.google.gwt.user.client.ui.ToggleButton;
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * View implementation of the {@link FeatureInfoControl}.
+ * The view consists of a simple togglebutton on a panel.
+ *
+ * @author Youri Flement
+ */
+public class FeatureInfoControlViewImpl implements FeatureInfoControlView {
+
+	private FeatureInfoControlPresenter presenter;
+
+	@UiField
+	protected HTMLPanel panel;
+
+	@UiField
+	protected ToggleButton button;
+
+	private static final FeatureInfoControlViewUiBinder UI_BINDER
+			= GWT.create(FeatureInfoControlViewUiBinder.class);
+
+	/**
+	 * {@link UiBinder} for this class.
+	 *
+	 * @author Youri Flement
+	 */
+	interface FeatureInfoControlViewUiBinder extends UiBinder<HTMLPanel, FeatureInfoControlViewImpl> {
+
+	}
+
+	public FeatureInfoControlViewImpl() {
+		UI_BINDER.createAndBindUi(this);
+
+		button.getElement().getStyle().setWidth(25, Unit.PX);
+		button.getElement().getStyle().setTextAlign(TextAlign.CENTER);
+	}
+
+	@UiHandler("button")
+	public void handleClick(ClickEvent event) {
+		if (button.isDown()) {
+			presenter.enableFeatureInfo();
+		} else {
+			presenter.disableFeatureInfo();
+		}
+	}
+
+	@Override
+	public void setPresenter(FeatureInfoControlPresenter presenter) {
+		this.presenter = presenter;
+	}
+
+	@Override
+	public Widget asWidget() {
+		return panel;
+	}
+}

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControlViewImpl.ui.xml
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControlViewImpl.ui.xml
@@ -1,0 +1,12 @@
+<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
+<ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder" xmlns:g="urn:import:com.google.gwt.user.client.ui">
+
+    <ui:with field='resource' type='org.geomajas.gwt2.example.base.client.resource.ShowcaseResource'/>
+
+    <g:HTMLPanel ui:field="panel">
+        <g:ToggleButton ui:field="button">
+            Info
+        </g:ToggleButton>
+    </g:HTMLPanel>
+
+</ui:UiBinder>

--- a/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControlWidget.java
+++ b/plugin/corewidget/example-jar/src/main/java/org/geomajas/gwt2/widget/example/client/sample/feature/featureinfo/control/FeatureInfoControlWidget.java
@@ -1,0 +1,40 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2014 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo.control;
+
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
+import org.geomajas.gwt2.client.map.MapPresenter;
+
+/**
+ * Widget for a control that allows to display feature information of features.
+ *
+ * @author Youri Flement
+ */
+public class FeatureInfoControlWidget implements IsWidget {
+
+	private FeatureInfoControlView view;
+
+	private FeatureInfoControlPresenter presenter;
+
+	public FeatureInfoControlWidget(MapPresenter mapPresenter) {
+		view = FeatureInfoControl.getInstance().getViewFactory().createFeatureInfoControlView();
+		presenter = new FeatureInfoControlPresenterImpl();
+		presenter.setMapPresenter(mapPresenter);
+		view.setPresenter(presenter);
+	}
+
+	@Override
+	public Widget asWidget() {
+		return view.asWidget();
+	}
+}

--- a/plugin/corewidget/example-jar/src/main/resources/org/geomajas/gwt2/widget/example/ExampleJar.gwt.xml
+++ b/plugin/corewidget/example-jar/src/main/resources/org/geomajas/gwt2/widget/example/ExampleJar.gwt.xml
@@ -12,9 +12,13 @@
   -->
 
 <module rename-to="widgetExamplejar">
-	<inherits name='org.geomajas.gwt2.example.base.ExampleBase' />
-	<inherits name='org.geomajas.gwt2.widget.CoreWidget' />
+    <inherits name='org.geomajas.gwt2.example.base.ExampleBase'/>
+    <inherits name='org.geomajas.gwt2.widget.CoreWidget'/>
     <inherits name='com.allen_sauer.gwt.dnd.gwt-dnd'/>
     <entry-point class="org.geomajas.gwt2.widget.example.client.ExampleJar"/>
-	<source path='client'/>
+    <source path='client'/>
+
+    <replace-with class="org.geomajas.gwt2.widget.example.client.sample.feature.featureinfo.MyAttributeWidgetFactory">
+        <when-type-is class="org.geomajas.gwt2.widget.client.feature.featureinfo.builder.AttributeWidgetFactory"/>
+    </replace-with>
 </module>

--- a/plugin/corewidget/example-jar/src/main/resources/org/geomajas/gwt2/widget/example/client/i18n/SampleMessages.properties
+++ b/plugin/corewidget/example-jar/src/main/resources/org/geomajas/gwt2/widget/example/client/i18n/SampleMessages.properties
@@ -94,3 +94,10 @@ itemSelectFirstItem=Hamster
 itemSelectSecondItem=Cat
 itemSelectThirdItem=Goldfish
 itemSelectYouSelected=You selected {0}!
+
+# -----------------------------------------------------------------------------
+# Messages for the Feature Info sample:
+# -----------------------------------------------------------------------------
+featureInfoTitle=Feature Information
+featureInfoShort=Demonstration of the feature information widget.
+featureInfoDescription=This example demonstrates the use of the FeatureInfoWidget. This widget displays information of features and has some functionality to interact with the feature (information).

--- a/server-extension/src/main/java/org/geomajas/gwt2/client/map/layer/VectorServerLayerImpl.java
+++ b/server-extension/src/main/java/org/geomajas/gwt2/client/map/layer/VectorServerLayerImpl.java
@@ -11,12 +11,6 @@
 
 package org.geomajas.gwt2.client.map.layer;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.geomajas.command.dto.RegisterNamedStyleInfoRequest;
 import org.geomajas.command.dto.RegisterNamedStyleInfoResponse;
 import org.geomajas.configuration.AttributeInfo;
@@ -49,9 +43,15 @@ import org.geomajas.gwt2.client.map.render.TileRenderer;
 import org.geomajas.sld.FeatureTypeStyleInfo;
 import org.geomajas.sld.RuleInfo;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Vector layer representation.
- * 
+ *
  * @author Pieter De Graef
  * @author Jan De Moerloose
  */
@@ -92,10 +92,10 @@ public class VectorServerLayerImpl extends AbstractServerLayer<ClientVectorLayer
 	@Override
 	public TileRenderer getTileRenderer() {
 		if (tileRenderer == null) {
-			 String layerId = layerInfo.getServerLayerId();
-			 String dispatcher = GeomajasServerExtension.getInstance().getEndPointService().getDispatcherUrl();
-			 String baseUrl = dispatcher + RASTERIZING_PREFIX + layerId + "@" + mapInfo.getCrs() + "/"
-			 + layerInfo.getNamedStyleInfo().getName() + "/";
+			String layerId = layerInfo.getServerLayerId();
+			String dispatcher = GeomajasServerExtension.getInstance().getEndPointService().getDispatcherUrl();
+			String baseUrl = dispatcher + RASTERIZING_PREFIX + layerId + "@" + mapInfo.getCrs() + "/"
+					+ layerInfo.getNamedStyleInfo().getName() + "/";
 			tileRenderer = new VectorServerTileRenderer(tileConfiguration, baseUrl, ".png");
 		}
 		return tileRenderer;


### PR DESCRIPTION
GWTII-164: Added Feature Info widget.
GWTII-164: Added option to zoom to feature object.
GWTII-164: Improved feature info control appearance.
GWTII-164: Refactored Feature Info Control to MVP.
GWTII-164: Using featureclicked handler instead of own map controller.
GWTII-164: Added option to show/hide feature info options.
