### PR TITLE
GWTII-220: remove sources dependencies from javadoc modules

### DIFF
--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -20,48 +20,28 @@
 
 	<artifactId>geomajas-client-gwt2-javadoc</artifactId>
 	<packaging>jar</packaging>
-	<name>Geomajas GWT 2 client: Javadoc</name>
-	<description>Geomajas GWT 2 client: Javadoc</description>
+	<name>Geomajas GWT2 client: Javadoc</name>
+	<description>Geomajas GWT2 client: Javadoc</description>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.geomajas</groupId>
 			<artifactId>geomajas-client-gwt2-api</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.geomajas</groupId>
-			<artifactId>geomajas-client-gwt2-api</artifactId>
-			<classifier>sources</classifier>
-		</dependency>
 
 		<dependency>
 			<groupId>org.geomajas</groupId>
 			<artifactId>geomajas-client-common-gwt</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.geomajas</groupId>
-			<artifactId>geomajas-client-common-gwt</artifactId>
-			<classifier>sources</classifier>
 		</dependency>
 
 		<dependency>
 			<groupId>org.geomajas</groupId>
 			<artifactId>geomajas-client-gwt2-impl</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.geomajas</groupId>
-			<artifactId>geomajas-client-gwt2-impl</artifactId>
-			<classifier>sources</classifier>
-		</dependency>
 
 		<dependency>
 			<groupId>org.geomajas</groupId>
 			<artifactId>geomajas-client-gwt2-server-extension</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.geomajas</groupId>
-			<artifactId>geomajas-client-gwt2-server-extension</artifactId>
-			<classifier>sources</classifier>
 		</dependency>
 
 		<dependency>
@@ -73,7 +53,6 @@
 
 	<build>
 		<plugins>
-
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<executions>
@@ -85,7 +64,6 @@
 						</goals>
 						<configuration>
 							<includeDependencySources>true</includeDependencySources>
-
 							<dependencySourceIncludes>
 								<dependencySourceInclude>org.geomajas:*</dependencySourceInclude>
 							</dependencySourceIncludes>
@@ -93,8 +71,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
 	</build>
-
 </project>

--- a/plugin/corewidget/javadoc/pom.xml
+++ b/plugin/corewidget/javadoc/pom.xml
@@ -20,19 +20,13 @@
 
 	<artifactId>geomajas-client-gwt2-plugin-corewidget-javadoc</artifactId>
 	<packaging>jar</packaging>
-	<name>Geomajas GWT 2 client: Plugin Corewidget - Javadoc</name>
-	<description>Geomajas GWT 2 client: Plugin Corewidget - Javadoc</description>
+	<name>Geomajas GWT2 client: Plugin Corewidget - Javadoc</name>
+	<description>Geomajas GWT2 client: Plugin Corewidget - Javadoc</description>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>org.geomajas.plugin</groupId>
 			<artifactId>geomajas-client-gwt2-plugin-corewidget</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.geomajas.plugin</groupId>
-			<artifactId>geomajas-client-gwt2-plugin-corewidget</artifactId>
-			<classifier>sources</classifier>
 		</dependency>
 
 		<dependency>
@@ -40,12 +34,10 @@
 			<artifactId>gwt-user</artifactId>
 			<scope>provided</scope>
 		</dependency>
-
 	</dependencies>
 
 	<build>
 		<plugins>
-
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<executions>
@@ -65,8 +57,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
 	</build>
-
 </project>

--- a/plugin/editing/javadoc/pom.xml
+++ b/plugin/editing/javadoc/pom.xml
@@ -20,39 +20,23 @@
 
 	<artifactId>geomajas-client-gwt2-plugin-editing-javadoc</artifactId>
 	<packaging>jar</packaging>
-	<name>Geomajas GWT 2 client: Plugin Editing - Javadoc</name>
-	<description>Geomajas GWT 2 client: Plugin Editing - Javadoc</description>
+	<name>Geomajas GWT2 client: Plugin Editing - Javadoc</name>
+	<description>Geomajas GWT2 client: Plugin Editing - Javadoc</description>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>org.geomajas.plugin</groupId>
 			<artifactId>geomajas-client-gwt2-plugin-editing-common</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.geomajas.plugin</groupId>
-			<artifactId>geomajas-client-gwt2-plugin-editing-common</artifactId>
-			<classifier>sources</classifier>
 		</dependency>
 
 		<dependency>
 			<groupId>org.geomajas.plugin</groupId>
 			<artifactId>geomajas-client-gwt2-plugin-editing-impl</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.geomajas.plugin</groupId>
-			<artifactId>geomajas-client-gwt2-plugin-editing-impl</artifactId>
-			<classifier>sources</classifier>
-		</dependency>
 
 		<dependency>
 			<groupId>org.geomajas.plugin</groupId>
 			<artifactId>geomajas-client-gwt2-plugin-editing-server-extension</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.geomajas.plugin</groupId>
-			<artifactId>geomajas-client-gwt2-plugin-editing-server-extension</artifactId>
-			<classifier>sources</classifier>
 		</dependency>
 
 		<dependency>
@@ -60,12 +44,10 @@
 			<artifactId>gwt-user</artifactId>
 			<scope>provided</scope>
 		</dependency>
-
 	</dependencies>
 
 	<build>
 		<plugins>
-
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<executions>
@@ -85,8 +67,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
 	</build>
-
 </project>

--- a/plugin/geocoder/javadoc/pom.xml
+++ b/plugin/geocoder/javadoc/pom.xml
@@ -20,19 +20,13 @@
 
 	<artifactId>geomajas-client-gwt2-plugin-geocoder-javadoc</artifactId>
 	<packaging>jar</packaging>
-	<name>Geomajas GWT 2 client: Plugin Geocoder - Javadoc</name>
-	<description>Geomajas GWT 2 client: Plugin Geocoder - Javadoc</description>
+	<name>Geomajas GWT2 client: Plugin Geocoder - Javadoc</name>
+	<description>Geomajas GWT2 client: Plugin Geocoder - Javadoc</description>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>org.geomajas.plugin</groupId>
 			<artifactId>geomajas-client-gwt2-plugin-geocoder</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.geomajas.plugin</groupId>
-			<artifactId>geomajas-client-gwt2-plugin-geocoder</artifactId>
-			<classifier>sources</classifier>
 		</dependency>
 
 		<dependency>
@@ -40,12 +34,10 @@
 			<artifactId>gwt-user</artifactId>
 			<scope>provided</scope>
 		</dependency>
-
 	</dependencies>
 
 	<build>
 		<plugins>
-
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<executions>
@@ -57,7 +49,6 @@
 						</goals>
 						<configuration>
 							<includeDependencySources>true</includeDependencySources>
-
 							<dependencySourceIncludes>
 								<dependencySourceInclude>org.geomajas.plugin:*</dependencySourceInclude>
 							</dependencySourceIncludes>
@@ -65,8 +56,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
 	</build>
-
 </project>

--- a/plugin/print/javadoc/pom.xml
+++ b/plugin/print/javadoc/pom.xml
@@ -20,28 +20,18 @@
 
 	<artifactId>geomajas-client-gwt2-plugin-print-javadoc</artifactId>
 	<packaging>jar</packaging>
-	<name>Geomajas GWT 2 client: Plugin print - Javadoc</name>
-	<description>Geomajas GWT 2 client: Plugin print - Javadoc</description>
+	<name>Geomajas GWT2 client: Plugin print - Javadoc</name>
+	<description>Geomajas GWT2 client: Plugin print - Javadoc</description>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.geomajas.plugin</groupId>
 			<artifactId>geomajas-client-gwt2-plugin-print-impl</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.geomajas.plugin</groupId>
-			<artifactId>geomajas-client-gwt2-plugin-print-impl</artifactId>
-			<classifier>sources</classifier>
-		</dependency>
 
 		<dependency>
 			<groupId>org.geomajas.plugin</groupId>
 			<artifactId>geomajas-client-gwt2-plugin-print-wms</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.geomajas.plugin</groupId>
-			<artifactId>geomajas-client-gwt2-plugin-print-wms</artifactId>
-			<classifier>sources</classifier>
 		</dependency>
 
 		<dependency>
@@ -49,12 +39,10 @@
 			<artifactId>gwt-user</artifactId>
 			<scope>provided</scope>
 		</dependency>
-
 	</dependencies>
 
 	<build>
 		<plugins>
-
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<executions>
@@ -66,7 +54,6 @@
 						</goals>
 						<configuration>
 							<includeDependencySources>true</includeDependencySources>
-
 							<dependencySourceIncludes>
 								<dependencySourceInclude>org.geomajas.plugin:*</dependencySourceInclude>
 							</dependencySourceIncludes>
@@ -74,8 +61,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
 	</build>
-
 </project>

--- a/plugin/tilebasedlayer/javadoc/pom.xml
+++ b/plugin/tilebasedlayer/javadoc/pom.xml
@@ -28,11 +28,6 @@
 			<groupId>org.geomajas.plugin</groupId>
 			<artifactId>geomajas-client-gwt2-plugin-tilebasedlayer</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.geomajas.plugin</groupId>
-			<artifactId>geomajas-client-gwt2-plugin-tilebasedlayer</artifactId>
-			<classifier>sources</classifier>
-		</dependency>
 
 		<dependency>
 			<groupId>com.google.gwt</groupId>
@@ -43,7 +38,6 @@
 
 	<build>
 		<plugins>
-
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<executions>
@@ -55,7 +49,6 @@
 						</goals>
 						<configuration>
 							<includeDependencySources>true</includeDependencySources>
-
 							<dependencySourceIncludes>
 								<dependencySourceInclude>org.geomajas.plugin:*</dependencySourceInclude>
 							</dependencySourceIncludes>
@@ -63,8 +56,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
 	</build>
-
 </project>

--- a/plugin/tms/javadoc/pom.xml
+++ b/plugin/tms/javadoc/pom.xml
@@ -20,19 +20,13 @@
 
 	<artifactId>geomajas-client-gwt2-plugin-tms-javadoc</artifactId>
 	<packaging>jar</packaging>
-	<name>Geomajas GWT 2 client: Plugin Tms - Javadoc</name>
-	<description>Geomajas GWT 2 client: Plugin Tms - Javadoc</description>
+	<name>Geomajas GWT2 client: Plugin Tms - Javadoc</name>
+	<description>Geomajas GWT2 client: Plugin Tms - Javadoc</description>
 
 	<dependencies>
-
 		<dependency>
 			<groupId>org.geomajas.plugin</groupId>
 			<artifactId>geomajas-client-gwt2-plugin-tms</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.geomajas.plugin</groupId>
-			<artifactId>geomajas-client-gwt2-plugin-tms</artifactId>
-			<classifier>sources</classifier>
 		</dependency>
 
 		<dependency>
@@ -40,12 +34,10 @@
 			<artifactId>gwt-user</artifactId>
 			<scope>provided</scope>
 		</dependency>
-
 	</dependencies>
 
 	<build>
 		<plugins>
-
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<executions>
@@ -57,7 +49,6 @@
 						</goals>
 						<configuration>
 							<includeDependencySources>true</includeDependencySources>
-
 							<dependencySourceIncludes>
 								<dependencySourceInclude>org.geomajas.plugin:*</dependencySourceInclude>
 							</dependencySourceIncludes>
@@ -65,8 +56,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
 	</build>
-
 </project>

--- a/plugin/wms/javadoc/pom.xml
+++ b/plugin/wms/javadoc/pom.xml
@@ -20,38 +20,23 @@
 
 	<artifactId>geomajas-client-gwt2-plugin-wms-javadoc</artifactId>
 	<packaging>jar</packaging>
-	<name>Geomajas GWT 2 client: Plugin Wms - Javadoc</name>
-	<description>Geomajas GWT 2 client: Plugin Wms - Javadoc</description>
+	<name>Geomajas GWT2 client: Plugin Wms - Javadoc</name>
+	<description>Geomajas GWT2 client: Plugin Wms - Javadoc</description>
 
 	<dependencies>
 		<dependency>
 			<groupId>org.geomajas.plugin</groupId>
 			<artifactId>geomajas-client-gwt2-plugin-print-wms</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.geomajas.plugin</groupId>
-			<artifactId>geomajas-client-gwt2-plugin-print-wms</artifactId>
-			<classifier>sources</classifier>
-		</dependency>
 
 		<dependency>
 			<groupId>org.geomajas.plugin</groupId>
 			<artifactId>geomajas-client-gwt2-plugin-wms</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.geomajas.plugin</groupId>
-			<artifactId>geomajas-client-gwt2-plugin-wms</artifactId>
-			<classifier>sources</classifier>
-		</dependency>
 
 		<dependency>
 			<groupId>org.geomajas.plugin</groupId>
 			<artifactId>geomajas-client-gwt2-plugin-wms-server-extension</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.geomajas.plugin</groupId>
-			<artifactId>geomajas-client-gwt2-plugin-wms-server-extension</artifactId>
-			<classifier>sources</classifier>
 		</dependency>
 
 		<dependency>
@@ -59,12 +44,10 @@
 			<artifactId>gwt-user</artifactId>
 			<scope>provided</scope>
 		</dependency>
-
 	</dependencies>
 
 	<build>
 		<plugins>
-
 			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<executions>
@@ -76,7 +59,6 @@
 						</goals>
 						<configuration>
 							<includeDependencySources>true</includeDependencySources>
-
 							<dependencySourceIncludes>
 								<dependencySourceInclude>org.geomajas.plugin:*</dependencySourceInclude>
 							</dependencySourceIncludes>
@@ -84,8 +66,6 @@
 					</execution>
 				</executions>
 			</plugin>
-
 		</plugins>
 	</build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -62,12 +62,6 @@
 				<artifactId>geomajas-client-gwt2-api</artifactId>
 				<version>${project.version}</version>
 			</dependency>
-			<dependency>
-				<groupId>org.geomajas</groupId>
-				<artifactId>geomajas-client-gwt2-api</artifactId>
-				<version>${project.version}</version>
-				<classifier>sources</classifier>
-			</dependency>
 
 			<dependency>
 				<groupId>org.geomajas</groupId>
@@ -80,23 +74,11 @@
 				<version>${project.version}</version>
 				<classifier>tests</classifier>
 			</dependency>
-			<dependency>
-				<groupId>org.geomajas</groupId>
-				<artifactId>geomajas-client-gwt2-impl</artifactId>
-				<version>${project.version}</version>
-				<classifier>sources</classifier>
-			</dependency>
 
 			<dependency>
 				<groupId>org.geomajas</groupId>
 				<artifactId>geomajas-client-gwt2-server-extension</artifactId>
 				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.geomajas</groupId>
-				<artifactId>geomajas-client-gwt2-server-extension</artifactId>
-				<version>${project.version}</version>
-				<classifier>sources</classifier>
 			</dependency>
 
 			<dependency>
@@ -110,12 +92,6 @@
 				<groupId>org.geomajas</groupId>
 				<artifactId>geomajas-client-common-gwt</artifactId>
 				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.geomajas</groupId>
-				<artifactId>geomajas-client-common-gwt</artifactId>
-				<version>${project.version}</version>
-				<classifier>sources</classifier>
 			</dependency>
 			<dependency>
 				<groupId>org.geomajas</groupId>
@@ -149,12 +125,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.geomajas.plugin</groupId>
-				<artifactId>geomajas-client-gwt2-plugin-corewidget</artifactId>
-				<version>${project.version}</version>
-				<classifier>sources</classifier>
-			</dependency>
-			<dependency>
-				<groupId>org.geomajas.plugin</groupId>
 				<artifactId>geomajas-client-gwt2-plugin-corewidget-example-jar</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -172,31 +142,13 @@
 			</dependency>
 			<dependency>
 				<groupId>org.geomajas.plugin</groupId>
-				<artifactId>geomajas-client-gwt2-plugin-editing-common</artifactId>
-				<version>${project.version}</version>
-				<classifier>sources</classifier>
-			</dependency>
-			<dependency>
-				<groupId>org.geomajas.plugin</groupId>
 				<artifactId>geomajas-client-gwt2-plugin-editing-impl</artifactId>
 				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.geomajas.plugin</groupId>
-				<artifactId>geomajas-client-gwt2-plugin-editing-impl</artifactId>
-				<version>${project.version}</version>
-				<classifier>sources</classifier>
 			</dependency>
             <dependency>
                 <groupId>org.geomajas.plugin</groupId>
                 <artifactId>geomajas-client-gwt2-plugin-editing-server-extension</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.geomajas.plugin</groupId>
-                <artifactId>geomajas-client-gwt2-plugin-editing-server-extension</artifactId>
-                <version>${project.version}</version>
-				<classifier>sources</classifier>
             </dependency>
 			<dependency>
 				<groupId>org.geomajas.plugin</groupId>
@@ -217,12 +169,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.geomajas.plugin</groupId>
-				<artifactId>geomajas-client-gwt2-plugin-geocoder</artifactId>
-				<version>${project.version}</version>
-				<classifier>sources</classifier>
-			</dependency>
-			<dependency>
-				<groupId>org.geomajas.plugin</groupId>
 				<artifactId>geomajas-client-gwt2-plugin-geocoder-example-jar</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -240,12 +186,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.geomajas.plugin</groupId>
-				<artifactId>geomajas-client-gwt2-plugin-print-impl</artifactId>
-				<version>${project.version}</version>
-				<classifier>sources</classifier>
-			</dependency>
-			<dependency>
-				<groupId>org.geomajas.plugin</groupId>
 				<artifactId>geomajas-client-gwt2-plugin-print-example-jar</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -253,12 +193,6 @@
 				<groupId>org.geomajas.plugin</groupId>
 				<artifactId>geomajas-client-gwt2-plugin-print-wms</artifactId>
 				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.geomajas.plugin</groupId>
-				<artifactId>geomajas-client-gwt2-plugin-print-wms</artifactId>
-				<version>${project.version}</version>
-				<classifier>sources</classifier>
 			</dependency>
 			<dependency>
 				<groupId>org.geomajas.plugin</groupId>
@@ -274,12 +208,6 @@
 			</dependency>
 			<dependency>
 				<groupId>org.geomajas.plugin</groupId>
-				<artifactId>geomajas-client-gwt2-plugin-tilebasedlayer</artifactId>
-				<version>${project.version}</version>
-				<classifier>sources</classifier>
-			</dependency>
-			<dependency>
-				<groupId>org.geomajas.plugin</groupId>
 				<artifactId>geomajas-client-gwt2-plugin-tilebasedlayer-example-jar</artifactId>
 				<version>${project.version}</version>
 			</dependency>
@@ -289,12 +217,6 @@
 				<groupId>org.geomajas.plugin</groupId>
 				<artifactId>geomajas-client-gwt2-plugin-tms</artifactId>
 				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.geomajas.plugin</groupId>
-				<artifactId>geomajas-client-gwt2-plugin-tms</artifactId>
-				<version>${project.version}</version>
-				<classifier>sources</classifier>
 			</dependency>
 			<dependency>
 				<groupId>org.geomajas.plugin</groupId>
@@ -315,20 +237,8 @@
 			</dependency>
 			<dependency>
 				<groupId>org.geomajas.plugin</groupId>
-				<artifactId>geomajas-client-gwt2-plugin-wms</artifactId>
-				<version>${project.version}</version>
-				<classifier>sources</classifier>
-			</dependency>
-			<dependency>
-				<groupId>org.geomajas.plugin</groupId>
 				<artifactId>geomajas-client-gwt2-plugin-wms-server-extension</artifactId>
 				<version>${project.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.geomajas.plugin</groupId>
-				<artifactId>geomajas-client-gwt2-plugin-wms-server-extension</artifactId>
-				<version>${project.version}</version>
-				<classifier>sources</classifier>
 			</dependency>
 			<dependency>
 				<groupId>org.geomajas.plugin</groupId>


### PR DESCRIPTION
All modules build normal, same size of target created.

Remark: locally, the javadoc module (not plugin) does not create a ...javadoc.jar . The one that is build on jenkins does contain a ...javadoc.jar.

NEEDS VOTE

Jan Venstermans: +1
