### PR TITLE
GWTII-231: remove CommonGwt inheritance in GeomajasClientApi.gwt.xml, ad...

### DIFF
--- a/api/src/main/resources/org/geomajas/gwt2/GeomajasClientApi.gwt.xml
+++ b/api/src/main/resources/org/geomajas/gwt2/GeomajasClientApi.gwt.xml
@@ -14,7 +14,6 @@
 	<inherits name="com.google.gwt.i18n.I18N"/>
 
 	<inherits name="org.geomajas.gwt.GeomajasCommonGwt"/>
-	<inherits name="org.geomajas.gwt.GeomajasCommonGwtCommand"/>
 	<inherits name='org.vaadin.gwtgraphics.GWTGraphics'/>
 
 	<source path="gwt2"/>

--- a/server-extension/src/main/resources/org/geomajas/gwt2/GeomajasClientServerExtension.gwt.xml
+++ b/server-extension/src/main/resources/org/geomajas/gwt2/GeomajasClientServerExtension.gwt.xml
@@ -11,6 +11,7 @@
 
 <module>
 	<inherits name="org.geomajas.gwt2.GeomajasClientImpl" />
+	<inherits name="org.geomajas.gwt.GeomajasCommonGwtCommand"/>
 
 	<source path="client">
 		<exclude name="*Test*.java" />


### PR DESCRIPTION
add to server extensions gwt.xml

full build is succssful, see http://ci.geomajas.org/jenkins/job/Geomajas%20Project%20GWT2%20client%20issue%20231/

example of showcase with these changes: http://dev.geomajas.org/geomajas-client-gwt2-example-GWTII-231_moveInheritCommonGwtCommand/

NEEDS VOTE
