### PR TITLE
GWTII-266: enable full compile, specifically for IE11

### DIFF
--- a/example/src/main/java/org/geomajas/gwt2/example/Example.gwt.xml
+++ b/example/src/main/java/org/geomajas/gwt2/example/Example.gwt.xml
@@ -31,7 +31,7 @@
 	<extend-property name="locale" values="nl"/>
 	<set-property-fallback name="locale" value="en"/>
 
-	<collapse-all-properties />
+	<!--<collapse-all-properties />-->
 
     <entry-point class="org.geomajas.gwt2.example.client.Example" />
 	<!-- set target browser to compile for, use this to limit to the browser used for testing -->


### PR DESCRIPTION
compare in IE11:
http://dev.geomajas.org/geomajas-client-gwt2-example-2.2.1-SNAPSHOT/
http://dev.geomajas.org/geomajas-client-gwt2-example-GWTII-266_IE11/
