### PR TITLE
GWTII-272: Change the default map resize behaviour to always keep the center

### DIFF
--- a/impl/src/main/java/org/geomajas/gwt2/client/map/ViewPortImpl.java
+++ b/impl/src/main/java/org/geomajas/gwt2/client/map/ViewPortImpl.java
@@ -16,7 +16,6 @@ import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import org.geomajas.geometry.Bbox;
 import org.geomajas.geometry.Coordinate;
 import org.geomajas.geometry.service.BboxService;
-import org.geomajas.gwt.client.map.RenderSpace;
 import org.geomajas.gwt.client.util.Dom;
 import org.geomajas.gwt2.client.animation.NavigationAnimation;
 import org.geomajas.gwt2.client.event.NavigationStopEvent;

--- a/impl/src/main/java/org/geomajas/gwt2/client/map/ViewPortImpl.java
+++ b/impl/src/main/java/org/geomajas/gwt2/client/map/ViewPortImpl.java
@@ -191,8 +191,6 @@ public final class ViewPortImpl implements ViewPort {
 	protected void setMapSize(int width, int height) {
 		if (this.mapWidth != width || this.mapHeight != height) {
 			View oldView = getView();
-			Coordinate screen = new Coordinate((double) width / 2.0, (double) height / 2.0);
-			position = getTransformationService().transform(screen, RenderSpace.SCREEN, RenderSpace.WORLD);
 			this.mapWidth = width;
 			this.mapHeight = height;
 			if (eventBus != null) {

--- a/impl/src/test/java/org/geomajas/gwt2/client/map/ViewPortEventTest.java
+++ b/impl/src/test/java/org/geomajas/gwt2/client/map/ViewPortEventTest.java
@@ -126,12 +126,14 @@ public class ViewPortEventTest {
 		Assert.assertNull(event);
 
 		HandlerRegistration reg = eventBus.addViewPortChangedHandler(new AllowChangedHandler());
-		viewPort.setMapSize(500, 500);
+		viewPort.setMapSize(1000, 500);
 
 		Assert.assertEquals(0.25, viewPort.getResolution());
-		Assert.assertTrue(viewPort.getPosition().equalsDelta(new Coordinate(-62.5, 62.5), 0.00001));
+		Assert.assertTrue(viewPort.getPosition().equalsDelta(new Coordinate(0, 0), 0.00001));
 		Assert.assertNotNull(event);
 		Assert.assertTrue(event instanceof ViewPortChangedEvent);
+		Assert.assertEquals(500, viewPort.getMapHeight());
+		Assert.assertEquals(1000, viewPort.getMapWidth());
 
 		reg.removeHandler();
 	}


### PR DESCRIPTION
Removed the lines that adjusted the center position.

My vote: +1 (binding)