### PR TITLE
GWTII-277: make geocoder widget css classes visible + set position via css

### DIFF
--- a/plugin/geocoder/documentation/src/docbkx/java-howto.xml
+++ b/plugin/geocoder/documentation/src/docbkx/java-howto.xml
@@ -20,23 +20,38 @@
     <title>Default Geocoder Widget</title>
 
     <para>The default Geocoder widget is class <code>org.geomajas.gwt2.plugin.geocoder.client.widget.GeocoderWidget</code>.
-		The following code creates the Geocoder Widget and
-		defines the position of the widget on the map:</para>
+		The following code creates the Geocoder Widget:</para>
 
-    <programlisting>GeocoderWidget geocoder = new GeocoderWidget(mapPresenter);
-geocoder.asWidget().getElement().getStyle().setTop(7, Style.Unit.PX);
-geocoder.asWidget().getElement().getStyle().setLeft(100, Style.Unit.PX);</programlisting>
+    <programlisting>GeocoderWidget geocoder = new GeocoderWidget(mapPresenter);</programlisting>
 
-    <para>Alternatively, the position can be set in the constructor:</para>
 
-	  <programlisting>GeocoderWidget geocoder = new GeocoderWidget(mapPresenter, 7, 100);</programlisting>
   </section>
+
+	<section>
+		<title>Customization of the Widget</title>
+
+		<para>An alternative constructor of the GeocoderWidget will take custom views.
+			The first view is the widget on the map; the second view presents different locations in case of multiple result to a search:</para>
+
+		<programlisting>GeocoderWidget geocoder = new GeocoderWidget(mapPresenter, customGeocderView,
+			customGeocoderAlternativesView);</programlisting>
+
+		<para>The position of the widget on the map is set via css class parameter ".gm-GeocoderGadget".
+			By default, the widget is positioned on the left top of the map, with values below:</para>
+
+		<programlisting>.gm-GeocoderGadget {
+	left: 100px;
+	top: 7px;
+}</programlisting>
+
+		<para>The position can be changed by overwriting these values in your own css file.</para>
+	</section>
 
   <section>
     <title>Default Geocoder Widget without css (no style)</title>
 
     <para>The geocoder widget can be loaded with empty css classes. This can be achieved by
-	setting the resource bundle factory <emphase>before</emphase> creating the widget:</para>
+	setting the resource bundle factory <emphasis>before</emphasis> creating the widget:</para>
 
 	  <programlisting>Geocoder.getInstance().setBundleFactory(new ExampleClientBundleFactoryNoStyle());
 // create the widget

--- a/plugin/geocoder/example-jar/src/main/java/org/geomajas/gwt2/plugin/geocoder/example/client/sample/GeoCoderExample.java
+++ b/plugin/geocoder/example-jar/src/main/java/org/geomajas/gwt2/plugin/geocoder/example/client/sample/GeoCoderExample.java
@@ -11,7 +11,6 @@
 package org.geomajas.gwt2.plugin.geocoder.example.client.sample;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.Style;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.DockLayoutPanel;
@@ -73,8 +72,6 @@ public class GeoCoderExample implements SamplePanel {
 
 		// create geocoder widget
 		GeocoderWidget geocoder = new GeocoderWidget(mapPresenter);
-		geocoder.asWidget().getElement().getStyle().setTop(7, Style.Unit.PX);
-		geocoder.asWidget().getElement().getStyle().setLeft(100, Style.Unit.PX);
 
 		// add geocoder widget to the map
 		mapPresenter.getWidgetPane().add(geocoder.asWidget());

--- a/plugin/geocoder/geocoder/src/main/resources/org/geomajas/gwt2/plugin/geocoder/client/widget/theme/default/geomajas-geocoderGadget-default.css
+++ b/plugin/geocoder/geocoder/src/main/resources/org/geomajas/gwt2/plugin/geocoder/client/widget/theme/default/geomajas-geocoderGadget-default.css
@@ -1,6 +1,9 @@
+@external .gm-*;
 .gm-GeocoderGadget {
 	position: absolute;
 	z-index: 1;
+    left: 100px;
+    top: 7px;
 }
 
 .gm-GeocoderGadget-textBox {


### PR DESCRIPTION
Example at http://dev.geomajas.org/geomajas-client-gwt2-example-for-GWTII-277_geocoderWidgetStyling/?sample=geocoder

Documentation update: 
http://dev.geomajas.org/docbkx-for-GWTII-277_geocoderWidgetStyling/html/master.html
(compare with current http://files.geomajas.org/documentation/geomajas-project-client-gwt2/2.2.0/geomajas-client-gwt2-plugin-geocoder-documentation/html/master.html)