### PR TITLE
GWTII-295: show full version number in showcase header

### DIFF
--- a/example-base/pom.xml
+++ b/example-base/pom.xml
@@ -53,6 +53,7 @@
 				<filtering>true</filtering>
 				<includes>
 					<include>META-INF/geomajasContext.xml</include>
+                    <include>org/geomajas/gwt2/example/base/client/resource/VersionMessages.properties</include>
 				</includes>
 			</resource>
 			<resource>
@@ -60,6 +61,7 @@
 				<filtering>false</filtering>
 				<excludes>
 					<exclude>META-INF/geomajasContext.xml</exclude>
+					<exclude>org/geomajas/gwt2/example/base/client/resource/VersionMessages.properties</exclude>
 				</excludes>
 			</resource>
 		</resources>

--- a/example-base/src/main/java/org/geomajas/gwt2/example/base/client/VersionUtil.java
+++ b/example-base/src/main/java/org/geomajas/gwt2/example/base/client/VersionUtil.java
@@ -1,0 +1,39 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.example.base.client;
+
+import com.google.gwt.core.client.GWT;
+import org.geomajas.gwt2.example.base.client.resource.VersionMessages;
+
+/**
+ * Get the version of current project.
+ * Inspired by {@link org.geomajas.gwt.client.Geomajas#getVersion()}
+ *
+ * @author Jan Venstermans
+ */
+public final class VersionUtil {
+
+	private static final VersionMessages MESSAGES = GWT.create(VersionMessages.class);
+
+	private VersionUtil() {
+	}
+
+	/**
+	 * Returns the current version of Geomajas as a string.
+	 *
+	 * @return Geomajas version
+	 */
+	public static String getVersion() {
+		return MESSAGES.version();
+	}
+
+}

--- a/example-base/src/main/java/org/geomajas/gwt2/example/base/client/resource/VersionMessages.java
+++ b/example-base/src/main/java/org/geomajas/gwt2/example/base/client/resource/VersionMessages.java
@@ -1,0 +1,24 @@
+/*
+ * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+ *
+ * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ *
+ * The program is available in open source according to the GNU Affero
+ * General Public License. All contributions in this program are covered
+ * by the Geomajas Contributors License Agreement. For full licensing
+ * details, see LICENSE.txt in the project root.
+ */
+
+package org.geomajas.gwt2.example.base.client.resource;
+
+import com.google.gwt.i18n.client.Messages;
+
+/**
+ * Messages to automatically get the correct GWT version from the pom.
+ *
+ * @author Joachim Van der Auwera
+ */
+public interface VersionMessages extends Messages {
+
+	String version();
+}

--- a/example-base/src/main/java/org/geomajas/gwt2/example/base/client/widget/Header.java
+++ b/example-base/src/main/java/org/geomajas/gwt2/example/base/client/widget/Header.java
@@ -12,9 +12,12 @@
 package org.geomajas.gwt2.example.base.client.widget;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
+import org.geomajas.gwt2.example.base.client.VersionUtil;
 
 /**
  * Page header for this showcase.
@@ -31,9 +34,13 @@ public class Header extends Composite {
 	interface MyUiBinder extends UiBinder<Widget, Header> {
 	}
 
+	@UiField
+	protected DivElement headerLabel;
+
 	private static final MyUiBinder UIBINDER = GWT.create(MyUiBinder.class);
 
 	public Header() {
 		initWidget(UIBINDER.createAndBindUi(this));
+		headerLabel.setInnerText("Showcase Client Gwt " + VersionUtil.getVersion());
 	}
 }

--- a/example-base/src/main/java/org/geomajas/gwt2/example/base/client/widget/Header.ui.xml
+++ b/example-base/src/main/java/org/geomajas/gwt2/example/base/client/widget/Header.ui.xml
@@ -30,7 +30,7 @@
 
 	<g:HTMLPanel addStyleNames="{style.header}">
 		<div class="{style.headerImageDiv}"><g:Image resource='{resource.geomajasLogoBg}' /></div>
-		<div class="{style.headerTitle}">Showcase Client Gwt 2.x</div>
+		<div class="{style.headerTitle}" ui:field="headerLabel"></div>
 	</g:HTMLPanel>
 
 </ui:UiBinder> 

--- a/example-base/src/main/resources/org/geomajas/gwt2/example/base/client/resource/VersionMessages.properties
+++ b/example-base/src/main/resources/org/geomajas/gwt2/example/base/client/resource/VersionMessages.properties
@@ -1,0 +1,11 @@
+#
+# This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
+#
+# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+#
+# The program is available in open source according to the GNU Affero
+# General Public License. All contributions in this program are covered
+# by the Geomajas Contributors License Agreement. For full licensing
+# details, see LICENSE.txt in the project root.
+#
+version=${project.version}


### PR DESCRIPTION
Added a static method that returns maven parameter project.version.
This method is in example-base module for the moment. In gwt client this method is in the impl module.